### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import argparse, os, subprocess
 
 def build(virus, spec):
 	'''
 	run build for single dataset
 	'''
-	print 'Processing ', virus, 'with spec ', spec
+	print('Processing ', virus, 'with spec ', spec)
 	download_with_fauna(virus, spec)
 	process_with_augur(virus, spec)
 
@@ -12,13 +13,13 @@ def download_with_fauna(virus, spec):
 	'''
 	download single dataset
 	'''
-	print 'Downloading with fauna'
+	print('Downloading with fauna')
 	os.chdir('fauna')
 	run = 'vdb/' + virus + '_download.py'
 	db = 'vdb'
 	fstem = virus
 	call = map(str, [params.bin, run, '-db', db, '-v', virus, '--fstem', virus])
-	print call
+	print(call)
 	subprocess.call(call)
 	os.chdir('..')
 
@@ -26,11 +27,11 @@ def process_with_augur(virus, spec):
 	'''
 	process single dataset
 	'''
-	print 'Processing with augur'
+	print('Processing with augur')
 	os.chdir('augur')
 	run = virus + '/' + virus + '.py'
 	call = map(str, [params.bin, run])
-	print call
+	print(call)
 	subprocess.call(call)
 	os.chdir('..')
 


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
